### PR TITLE
Make the component SSRable

### DIFF
--- a/src/Canvas.svelte
+++ b/src/Canvas.svelte
@@ -29,12 +29,6 @@
   const resize = () => (resizeNeeded = true);
 
   const draw = () => {
-    if (typeof window === "undefined") {
-      resizeNeeded = false;
-      redrawNeeded = false;
-      return;
-    }
-
     if (resizeNeeded) {
       context.scale(pixelRatio, pixelRatio);
       resizeNeeded = false;
@@ -87,16 +81,15 @@
 
   setContext(KEY, { register, redraw });
 
-  onMount(() => {
+  if (pixelRatio === undefined) {
     if (typeof window === "undefined") {
       pixelRatio = 2;
-      return
+    } else {
+      pixelRatio = window.devicePixelRatio;
     }
-    
-    if(pixelRatio === undefined) {
-      pixelRatio = window.devicePixelRatio || 2;
-    }
+  }
 
+  onMount(() => {
     context = canvas.getContext("2d");
     draw();
   });

--- a/src/Canvas.svelte
+++ b/src/Canvas.svelte
@@ -29,6 +29,12 @@
   const resize = () => (resizeNeeded = true);
 
   const draw = () => {
+    if (typeof window === "undefined") {
+      resizeNeeded = false;
+      redrawNeeded = false;
+      return;
+    }
+
     if (resizeNeeded) {
       context.scale(pixelRatio, pixelRatio);
       resizeNeeded = false;
@@ -65,7 +71,7 @@
       redrawNeeded = false;
     }
 
-    requestAnimationFrame(draw);
+    window.requestAnimationFrame(draw);
   };
 
   const register = ({ setup, renderer }) => {
@@ -82,9 +88,15 @@
   setContext(KEY, { register, redraw });
 
   onMount(() => {
-    if (pixelRatio === undefined) {
+    if (typeof window === "undefined") {
+      pixelRatio = 2;
+      return
+    }
+    
+    if(pixelRatio === undefined) {
       pixelRatio = window.devicePixelRatio || 2;
     }
+
     context = canvas.getContext("2d");
     draw();
   });

--- a/src/timer.js
+++ b/src/timer.js
@@ -4,9 +4,16 @@ let frame
 
 const now = Date.now()
 
-export default readable(Date.now() - now, function start(set) {
-  frame = requestAnimationFrame(() => start(set))
+function start(set) {
   set(Date.now() - now)
 
-  return () => cancelAnimationFrame(frame)
-})
+  frame = window.requestAnimationFrame(() => start(set))
+  return () => window.cancelAnimationFrame(frame)
+}
+
+function noop() {}
+
+export default readable(
+  Date.now() - now,
+  typeof window === 'undefined' ? noop : start
+)


### PR DESCRIPTION
I'm starting to play around with canvas and found `svelte-canvas`, so thanks for it 😁 . 

However, after trying to add it to my sapper playground I saw that it wasn't considering a server-side environment. This PR is kind of simplistic but makes it work!

~(Also not perfect, there's a loose `NaN` in the `width` and `height` props. Will fix that tomorrow from here.)~

**Screenshots:**

**Page's source code**
![image](https://user-images.githubusercontent.com/12702016/88129019-71f6c580-cbad-11ea-8786-265570347a2b.png)

Used the example provided in the readme