### PR TITLE
fix: `mouseenter` coordinates are not offset

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -89,7 +89,7 @@
     const x = e.offsetX * _pixelRatio;
     const y = e.offsetY * _pixelRatio;
     const id = (<HitCanvasRenderingContext2D>context).getLayerIdAt(x, y);
-    manager.setActiveLayer(id, e);
+    manager.setActiveLayer(id, e, canvas.getBoundingClientRect());
     manager.dispatchLayerEvent(e);
   };
 

--- a/src/lib/util/LayerManager.ts
+++ b/src/lib/util/LayerManager.ts
@@ -143,24 +143,24 @@ class LayerManager {
     }
   }
 
-  setActiveLayer(layer: number, e: MouseEvent | TouchEvent) {
+  setActiveLayer(layer: number, e: MouseEvent | TouchEvent, boundingClientRect?: DOMRect) {
     if (this.activeLayerId === layer) return;
 
     if (e instanceof MouseEvent) {
-      this.dispatchLayerEvent(new PointerEvent('pointerleave', e));
-      this.dispatchLayerEvent(new MouseEvent('mouseleave', e));
+      this.dispatchLayerEvent(new PointerEvent('pointerleave', e), boundingClientRect);
+      this.dispatchLayerEvent(new MouseEvent('mouseleave', e), boundingClientRect);
     }
 
     this.activeLayerId = layer;
     this.activeLayerDispatcher = this.dispatchers.get(layer);
 
     if (e instanceof MouseEvent) {
-      this.dispatchLayerEvent(new PointerEvent('pointerenter', e));
-      this.dispatchLayerEvent(new MouseEvent('mouseenter', e));
+      this.dispatchLayerEvent(new PointerEvent('pointerenter', e), boundingClientRect);
+      this.dispatchLayerEvent(new MouseEvent('mouseenter', e), boundingClientRect);
     }
   }
 
-  dispatchLayerEvent(e: MouseEvent | TouchEvent) {
+  dispatchLayerEvent(e: MouseEvent | TouchEvent, boundingClientRect?: DOMRect|undefined) {
     if (!this.activeLayerDispatcher) return;
 
     if (window.TouchEvent && e instanceof TouchEvent) {
@@ -173,10 +173,10 @@ class LayerManager {
       };
 
       this.activeLayerDispatcher(<Events>e.type, detail);
-    } else if (e instanceof MouseEvent) {
+    } else if (e instanceof MouseEvent || e instanceof PointerEvent) {
       const detail: LayerEventDetail = {
-        x: e.offsetX,
-        y: e.offsetY,
+        x: boundingClientRect ? e.clientX - boundingClientRect.left : e.offsetX,
+        y: boundingClientRect ? e.clientY - boundingClientRect.top : e.offsetY,
         originalEvent: e,
       };
 


### PR DESCRIPTION
I was trying to do some actions based on the x / y coordinates of the `mouseenter` event, but since the fake events created by `setActiveLayer` can't set a `target` their `offsetX` / `offsetY` becomes the same as `clientX` / `clientY`.

This PR forwards the result of `canvas.getBoundingClientRect()` to `setActiveLayer()` for mouse moves and will use that to calculate `offsetX` / `offsetY` from `clientX` / `clientY` in `dispatchLayerEvent()`