### PR TITLE
refactor: directly import data from NPM packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-canvas",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-canvas",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "canvas-size": "^1.2.6",
@@ -39,7 +39,9 @@
         "topojson-client": "^3.1.0",
         "tslib": "^2.6.2",
         "typescript": "^5.2.2",
-        "vite": "^5.0.0"
+        "us-atlas": "^3.0.1",
+        "vite": "^5.0.0",
+        "world-atlas": "^2.0.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3488,6 +3490,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/us-atlas": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/us-atlas/-/us-atlas-3.0.1.tgz",
+      "integrity": "sha512-wEIZCq0ImPvGblTd8gZMqNNCPkQshugMUG/8nkSWXb02+XqNFREg9atHOKP9w6prLZTpqcLhSvdBW81MkV3/0Q==",
+      "dev": true
+    },
     "node_modules/vfile": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
@@ -3633,6 +3641,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/world-atlas": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz",
+      "integrity": "sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ==",
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -5994,6 +6008,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "us-atlas": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/us-atlas/-/us-atlas-3.0.1.tgz",
+      "integrity": "sha512-wEIZCq0ImPvGblTd8gZMqNNCPkQshugMUG/8nkSWXb02+XqNFREg9atHOKP9w6prLZTpqcLhSvdBW81MkV3/0Q==",
+      "dev": true
+    },
     "vfile": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
@@ -6069,6 +6089,12 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "world-atlas": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz",
+      "integrity": "sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ==",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "topojson-client": "^3.1.0",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "us-atlas": "^3.0.1",
+    "vite": "^5.0.0",
+    "world-atlas": "^2.0.2"
   },
   "type": "module",
   "exports": {

--- a/src/routes/examples/canvas-svg/App.svelte
+++ b/src/routes/examples/canvas-svg/App.svelte
@@ -1,23 +1,14 @@
 <script>
-  import { onMount } from 'svelte';
   import { Canvas } from '$lib';
   import { mesh, feature } from 'topojson-client';
   import { geoIdentity, geoPath } from 'd3-geo';
   import Bubble from './Bubble.svelte';
+  import us from 'us-atlas/states-albers-10m.json';
 
   let width;
 
   $: projection = geoIdentity().scale(width / 975);
   $: path = geoPath(projection);
-
-  let us;
-
-  onMount(async () => {
-    const data = await fetch(
-      'https://cdn.jsdelivr.net/npm/us-atlas@3/states-albers-10m.json',
-    );
-    us = await data.json();
-  });
 
   $: centroids = us
     ? feature(us, us.objects.states)

--- a/src/routes/examples/globe/App.svelte
+++ b/src/routes/examples/globe/App.svelte
@@ -1,16 +1,11 @@
 <script>
   import { Canvas, Layer } from '$lib';
-  import { onMount } from 'svelte';
   import { geoOrthographic, geoGraticule10, geoPath } from 'd3-geo';
   import { feature } from 'topojson-client';
+  import land from 'world-atlas/land-110m.json';
 
-  let width, map;
-
-  onMount(() =>
-    fetch('https://cdn.jsdelivr.net/npm/world-atlas@2/land-110m.json')
-      .then((data) => data.json())
-      .then((data) => (map = feature(data, 'land'))),
-  );
+  let width,
+    map = feature(land, 'land');
 
   $: pad = width * 0.02;
 


### PR DESCRIPTION
Simplifies the examples `canvas-svg` and `globe`.

Just a minor nitpick that I noticed while having a similar use case to this example; if this isn't used; I would be quite curious as to why fetch was used over import.